### PR TITLE
OGP facebook:app_idとtwitterページの修正、_card.vueも北九州化

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,7 +23,7 @@ const config: Configuration = {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://stopcovid19.metro.kitakyusyu.jp'
+        content: 'https://stopcovid19-kitakyusyu.jp'
       },
       {
         hid: 'twitter:card',
@@ -33,17 +33,17 @@ const config: Configuration = {
       {
         hid: 'twitter:site',
         name: 'twitter:site',
-        content: '@tokyo_bousai'
+        content: '@city_kitakyushu'
       },
       {
         hid: 'twitter:creator',
         name: 'twitter:creator',
-        content: '@tokyo_bousai'
+        content: '@city_kitakyushu'
       },
       {
         hid: 'fb:app_id',
         property: 'fb:app_id',
-        content: '2879625188795443'
+        content: '166197104765804'
       },
       {
         hid: 'note:card',

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -131,14 +131,14 @@ export default {
     return data
   },
   head() {
-    const url = 'https://stopcovid19.metro.tokyo.lg.jp'
+    const url = 'https://stopcovid19-kitakyushu.jp'
     const timestamp = new Date().getTime()
     const ogpImage =
       this.$i18n.locale === 'ja'
         ? `${url}/ogp/${this.$route.params.card}.png?t=${timestamp}`
         : `${url}/ogp/${this.$i18n.locale}/${this.$route.params.card}.png?t=${timestamp}`
     const description = `${this.updatedAt} | ${this.$t(
-      '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
+      '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、北九州市が開設したものです。'
     )}`
 
     return {
@@ -155,7 +155,7 @@ export default {
           content:
             this.title +
             ' | ' +
-            this.$t('東京都') +
+            this.$t('北九州市') +
             ' ' +
             this.$t('新型コロナウイルス感染症') +
             this.$t('対策サイト')


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #13 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- facebookのapp_idを取得し、東京のidから変更(いづれ正規のidに変えたい)
- twitterのリンクページを北九州市公式ページに設定
- _card.vueのog url, titleを北九州に変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
