### PR TITLE
北九州市ロゴのサイズ調整

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -364,6 +364,7 @@ export default Vue.extend({
 }
 
 .SideNavigation-HeaderLogo {
+  width: 200px;
   @include lessThan($tiny) {
     width: 100px;
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #125

## ⛏ 変更内容 / Details of Changes
- defaultのロゴ横幅が指定されていなかったので、200px に設定した
　横幅が320px 以下になると 100px にするところは変更していない

## 📸 スクリーンショット / Screenshots
