### PR TITLE
検査陽性者の状況カードを追加

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -1,6 +1,6 @@
 // ==================
 // color
-$green-1: #483d68;
+$green-1: #1e6ace;
 $green-2: #125e9d;
 $green-3: #007ebf;
 $green-4: #0080ff;

--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -1,76 +1,97 @@
 <template>
   <ul :class="$style.container">
-    <li :class="[$style.box, $style.tall, $style.parent, $style.confirmed]">
-      <div :class="$style.pillar">
-        <div :class="$style.content">
-          <span>
-            {{ $t('陽性者数') }}
-            <br />({{ $t('累計') }})
-          </span>
-          <span>
-            <strong>{{ 陽性者数.toLocaleString() }}</strong>
-            <span :class="$style.unit">{{ $t('人') }}</span>
-          </span>
-        </div>
+    <li :class="[$style.box, $style.parent]">
+      <div :class="$style.content">
+        <span> {{ $t('陽性者数') }} ({{ $t('累計') }}) </span>
+        <span>
+          <strong>{{ 陽性者数.toLocaleString() }}</strong>
+          <span :class="$style.unit">{{ $t('人') }}</span>
+        </span>
       </div>
       <ul :class="$style.group">
-        <li :class="[$style.box, $style.parent, $style.hospitalized]">
-          <div :class="$style.pillar">
-            <div :class="$style.content">
-              <span>{{ $t('入院中') }}</span>
-              <span>
-                <strong>{{ 入院中.toLocaleString() }}</strong>
-                <span :class="$style.unit">{{ $t('人') }}</span>
-              </span>
-            </div>
+        <li :class="[$style.box, $style.parent]">
+          <div :class="$style.content">
+            <span>{{ $t('入院') }}</span>
+            <span>
+              <strong>{{ 入院中.toLocaleString() }}</strong>
+              <span :class="$style.unit">{{ $t('人') }}</span>
+            </span>
           </div>
           <ul :class="$style.group">
-            <li :class="[$style.box, $style.short, $style.minor]">
-              <div :class="$style.pillar">
-                <div :class="$style.content">
-                  <!-- eslint-disable vue/no-v-html-->
-                  <span v-html="$t('軽症・<br />中等症')" />
-                  <!-- eslint-enable vue/no-v-html-->
-                  <span>
-                    <strong>{{ 軽症中等症.toLocaleString() }}</strong>
-                    <span :class="$style.unit">{{ $t('人') }}</span>
-                  </span>
-                </div>
+            <li :class="[$style.box]">
+              <div :class="$style.content">
+                <span>{{ $t('無症状') }}</span>
+                <span>
+                  <strong>{{ 無症状.toLocaleString() }}</strong>
+                  <span :class="$style.unit">{{ $t('人') }}</span>
+                </span>
               </div>
             </li>
-            <li :class="[$style.box, $style.short, $style.severe]">
-              <div :class="$style.pillar">
-                <div :class="$style.content">
-                  <span>{{ $t('重症') }}</span>
-                  <span>
-                    <strong>{{ 重症.toLocaleString() }}</strong>
-                    <span :class="$style.unit">{{ $t('人') }}</span>
-                  </span>
-                </div>
+            <li :class="[$style.box]">
+              <div :class="$style.content">
+                <!-- eslint-disable vue/no-v-html-->
+                <span v-html="$t('軽症・中等症')" />
+                <!-- eslint-enable vue/no-v-html-->
+                <span>
+                  <strong>{{ 軽症中等症.toLocaleString() }}</strong>
+                  <span :class="$style.unit">{{ $t('人') }}</span>
+                </span>
+              </div>
+            </li>
+            <li :class="[$style.box]">
+              <div :class="$style.content">
+                <span>{{ $t('重症') }}</span>
+                <span>
+                  <strong>{{ 重症.toLocaleString() }}</strong>
+                  <span :class="$style.unit">{{ $t('人') }}</span>
+                </span>
+              </div>
+            </li>
+            <li :class="[$style.box]">
+              <div :class="$style.content">
+                <span>{{ $t('確認中') }}</span>
+                <span>
+                  <strong>{{ 確認中.toLocaleString() }}</strong>
+                  <span :class="$style.unit">{{ $t('人') }}</span>
+                </span>
               </div>
             </li>
           </ul>
         </li>
-        <li :class="[$style.box, $style.deceased]">
-          <div :class="$style.pillar">
-            <div :class="$style.content">
-              <span>{{ $t('死亡') }}</span>
-              <span>
-                <strong>{{ 死亡.toLocaleString() }}</strong>
-                <span :class="$style.unit">{{ $t('人') }}</span>
-              </span>
-            </div>
+        <li :class="[$style.box]">
+          <div :class="$style.content">
+            <span>{{ $t('自宅療養') }}</span>
+            <span>
+              <strong>{{ 自宅療養.toLocaleString() }}</strong>
+              <span :class="$style.unit">{{ $t('人') }}</span>
+            </span>
           </div>
         </li>
-        <li :class="[$style.box, $style.recovered]">
-          <div :class="$style.pillar">
-            <div :class="$style.content">
-              <span>{{ $t('退院') }}</span>
-              <span>
-                <strong>{{ 退院.toLocaleString() }}</strong>
-                <span :class="$style.unit">{{ $t('人') }}</span>
-              </span>
-            </div>
+        <li :class="[$style.box]">
+          <div :class="$style.content">
+            <span>{{ $t('入院・療養等調整中') }}</span>
+            <span>
+              <strong>{{ 調整中.toLocaleString() }}</strong>
+              <span :class="$style.unit">{{ $t('人') }}</span>
+            </span>
+          </div>
+        </li>
+        <li :class="[$style.box]">
+          <div :class="$style.content">
+            <span>{{ $t('死亡') }}</span>
+            <span>
+              <strong>{{ 死亡.toLocaleString() }}</strong>
+              <span :class="$style.unit">{{ $t('人') }}</span>
+            </span>
+          </div>
+        </li>
+        <li :class="[$style.box]">
+          <div :class="$style.content">
+            <span>{{ $t('退院等（療養期間経過を含む）') }}</span>
+            <span>
+              <strong>{{ 退院.toLocaleString() }}</strong>
+              <span :class="$style.unit">{{ $t('人') }}</span>
+            </span>
           </div>
         </li>
       </ul>
@@ -80,7 +101,6 @@
 
 <script lang="ts">
 import Vue from 'vue'
-
 /* eslint-disable vue/prop-name-casing */
 export default Vue.extend({
   props: {
@@ -96,11 +116,27 @@ export default Vue.extend({
       type: Number,
       required: true
     },
+    無症状: {
+      type: Number,
+      required: true
+    },
     軽症中等症: {
       type: Number,
       required: true
     },
     重症: {
+      type: Number,
+      required: true
+    },
+    確認中: {
+      type: Number,
+      required: true
+    },
+    自宅療養: {
+      type: Number,
+      required: true
+    },
+    調整中: {
       type: Number,
       required: true
     },
@@ -112,181 +148,92 @@ export default Vue.extend({
       type: Number,
       required: true
     }
-  },
-  methods: {
-    /** 桁数に応じて位置の調整をする */
-    getAdjustX(input: number) {
-      const length = input.toString(10).length
-      switch (length) {
-        case 1: {
-          return 3
-        }
-        case 2: {
-          return 0
-        }
-        case 3: {
-          return -3
-        }
-        case 4: {
-          return -8
-        }
-        default: {
-          return 0
-        }
-      }
-    }
   }
 })
 </script>
 
 <style lang="scss" module>
 $default-bdw: 3px;
-$default-boxh: 150px;
 $default-boxdiff: 35px;
-
 // .container > .box > (.group > .box > ...) .pillar > .content
-
 .container {
   width: 100%;
-  display: flex;
-  justify-content: center;
   box-sizing: border-box;
   color: $green-1;
   line-height: 1.35;
-
   * {
     box-sizing: border-box;
   }
   // override default styles
   padding-left: 0 !important;
-
   ul {
     padding-left: 0;
   }
 }
-
-.pillar {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  flex: 0 0 auto;
-  text-align: center;
-  width: 100%;
-  border: $default-bdw solid $green-1;
-}
-
 .group {
-  display: flex;
   flex: 0 0 auto;
-  padding-left: 0;
-  padding-top: $default-bdw;
+  padding-left: $default-bdw !important;
   border-top: $default-bdw solid $green-1;
   border-left: $default-bdw solid $green-1;
 }
-
-.box {
-  display: flex;
-
-  &.parent {
-    border-top: $default-bdw solid $green-1;
-    border-left: $default-bdw solid $green-1;
-    position: relative;
-    padding-top: $default-boxdiff - $default-bdw * 2;
-
-    &::after {
-      content: '';
-      display: block;
-      position: absolute;
-      top: -1px;
-      right: 0;
-      height: $default-boxdiff - $default-bdw - 2;
-      border-left: $default-bdw solid $green-1;
-    }
-
-    > .pillar {
-      margin-top: -($default-boxdiff - $default-bdw * 2);
-      border-top: none;
-      border-right: none;
-      border-left: none;
-    }
-  }
-
-  &.confirmed {
-    width: 100%;
-
-    > .pillar {
-      // [6列] 1/6
-      width: calc((100% + #{$default-bdw} * 2) / 6 - #{$default-bdw} * 3);
-    }
-
-    > .group {
-      // [6列] 5/6
-      width: calc((100% + #{$default-bdw} * 2) / 6 * 5 + #{$default-bdw});
-    }
-  }
-
-  &.hospitalized {
-    margin-left: $default-bdw;
-    // [5列] 3/5
-    width: calc(100% / 5 * 3 - #{$default-bdw});
-
-    > .pillar {
-      // [3列] 1/3
-      width: calc((100% + #{$default-bdw} * 2) / 3 - #{$default-bdw} * 3);
-    }
-
-    > .group {
-      // [3列] 2/3
-      width: calc((100% + #{$default-bdw} * 2) / 3 * 2 + #{$default-bdw});
-    }
-  }
-
-  &.minor,
-  &.severe {
-    margin-left: $default-bdw;
-    // [2列] 1/2
-    width: calc(100% / 2 - #{$default-bdw});
-  }
-
-  &.deceased,
-  &.recovered {
-    margin-left: $default-bdw;
-    // [5列] 1/5
-    width: calc(100% / 5 - #{$default-bdw});
-  }
-}
-
 .content {
-  min-height: $default-boxh;
-  padding: 10px 2px;
+  padding: 5px 10px;
   display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
-
+  width: 100%;
+  border: $default-bdw solid $green-1;
   > span {
     display: block;
-    width: 100%;
-
-    @include font-size(16);
-
-    &:last-child {
-      margin-top: 0.1em;
+    @include font-size(14);
+    &:first-child {
+      text-align: left;
+      margin-top: 1px;
+      flex-shrink: 2;
     }
-
+    &:last-child {
+      margin-left: 10px;
+      text-align: right;
+      // white-space: nowrap;
+      flex-shrink: 1;
+    }
     &:not(:last-child) {
       overflow-wrap: break-word;
     }
   }
-  span strong {
-    @include font-size(18);
-  }
-
-  span.unit {
+  strong {
     @include font-size(16);
   }
+  span.unit {
+    @include font-size(14);
+  }
 }
-
+.box {
+  display: block;
+  margin-top: $default-bdw;
+  &.parent {
+    border-top: $default-bdw solid $green-1;
+    border-left: $default-bdw solid $green-1;
+    position: relative;
+    padding-left: $default-boxdiff - $default-bdw * 2;
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      left: -1px;
+      bottom: 0;
+      width: $default-boxdiff - $default-bdw - 2;
+      border-bottom: $default-bdw solid $green-1;
+    }
+    > .content {
+      margin-left: -($default-boxdiff - $default-bdw * 2);
+      width: calc(100% + #{($default-boxdiff - $default-bdw * 2)});
+      border-top: none;
+      border-left: none;
+      border-bottom: none;
+    }
+  }
+}
 @function px2vw($px, $vw: 0) {
   @if $vw > 0 {
     @return ceil($px / $vw * 100000vw) / 1000;
@@ -294,122 +241,58 @@ $default-boxdiff: 35px;
     @return $px * 1px;
   }
 }
-
-@mixin override($vw, $bdw, $fz, $boxh, $boxdiff) {
-  .pillar {
-    border-width: px2vw($bdw, $vw);
-  }
-
+@mixin override($vw, $bdw, $fz, $boxdiff) {
   .group {
-    padding-top: px2vw($bdw, $vw);
-    border-top-width: px2vw($bdw, $vw);
-    border-left-width: px2vw($bdw, $vw);
+    padding-left: px2vw($bdw, $vw) !important;
+    border-top: px2vw($bdw, $vw) solid $green-1;
+    border-left: px2vw($bdw, $vw) solid $green-1;
   }
-
   .content {
+    padding: px2vw(5, $vw) px2vw(10, $vw);
+    border: px2vw($bdw, $vw) solid $green-1;
     > span {
       @include font-size($fz);
+      &:first-child {
+        margin-top: px2vw(1, $vw);
+      }
+      &:last-child {
+        margin-left: 10px;
+      }
     }
-    span strong {
+    strong {
       @include font-size($fz + 2);
     }
-
     span.unit {
       @include font-size($fz);
     }
   }
-
   .box {
+    margin-top: px2vw($bdw, $vw);
     &.parent {
-      border-top-width: px2vw($bdw, $vw);
-      border-left-width: px2vw($bdw, $vw);
-      padding-top: px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2;
-
+      border-top: px2vw($bdw, $vw) solid $green-1;
+      border-left: px2vw($bdw, $vw) solid $green-1;
+      padding-left: px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2;
       &::after {
-        height: px2vw($boxdiff - $bdw, $vw);
-        border-left-width: px2vw($bdw, $vw);
+        width: px2vw($boxdiff - $bdw, $vw);
+        border-bottom: px2vw($bdw, $vw) solid $green-1;
       }
-
-      > .pillar {
-        margin-top: px2vw((-($boxdiff - $bdw * 2)), $vw);
+      > .content {
+        margin-left: -(px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2);
+        width: calc(100% + #{(px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2)});
       }
-    }
-
-    &.confirmed {
-      > .pillar {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 6 - #{px2vw($bdw, $vw)} * 3
-        );
-      }
-
-      > .group {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 6 * 5 + #{px2vw($bdw, $vw)}
-        );
-      }
-    }
-
-    &.hospitalized {
-      margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 5 * 3 - #{px2vw($bdw, $vw)});
-
-      > .pillar {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 3 - #{px2vw($bdw, $vw)} * 3
-        );
-      }
-
-      > .group {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 3 * 2 + #{px2vw($bdw, $vw)}
-        );
-      }
-    }
-
-    &.minor,
-    &.severe {
-      margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 2 - #{px2vw($bdw, $vw)});
-    }
-
-    &.deceased,
-    &.recovered {
-      margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 5 - #{px2vw($bdw, $vw)});
     }
   }
 }
-
-// variables.scss Breakpoints: huge (1440)
-@include lessThan(1440) {
-  @include override(1440, 3, 15, 150, 35);
-}
-
 // Vuetify Breakpoints: Large (1264)
 @include lessThan(1263) {
-  @include override(1263, 2, 13, 107, 24);
+  @include override(1263, 3, 14, 35);
 }
-
-// variables.scss Breakpoints: large (1170)
-@include lessThan(1170) {
-  @include override(1170, 2, 13, 107, 24);
-}
-
 // Vuetify Breakpoints: Small (960)
 @include lessThan(959) {
-  @include override(960, 4, 14, 180, 40);
+  @include override(960, 3, 14, 35);
 }
-
-@include lessThan(767) {
-  @include override(960, 3, 14, 180, 40);
-}
-
 // Vuetify Breakpoints: Extra Small (600)
 @include lessThan(600) {
-  @include override(600, 3, 14, 150, 35);
-}
-
-@include lessThan(420) {
-  @include override(600, 2, 12, 150, 35);
+  @include override(600, 3, 14, 35);
 }
 </style>

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -5,12 +5,23 @@
       :title-id="'details-of-confirmed-cases'"
       :date="Data.patients.date"
     >
-      <template v-slot:button>
-        <p :class="$style.note">
-          {{
-            $t('（注）「入院中」には、入院調整中・宿泊療養に移行した方を含む')
-          }}
-        </p>
+      <template v-slot:description>
+        <ul>
+          <li>
+            {{
+              $t(
+                '（注）「重症」は、集中治療室（ICU）等での管理又は人工呼吸器管理が必要な患者数'
+              )
+            }}
+          </li>
+          <li>
+            {{
+              $t(
+                '（注）退院者数の把握には一定の期間を要しており、確認次第数値を更新している'
+              )
+            }}
+          </li>
+        </ul>
       </template>
       <confirmed-cases-details-table
         :aria-label="$t('検査陽性者の状況')"
@@ -20,21 +31,11 @@
   </v-col>
 </template>
 
-<style lang="scss" module>
-.note {
-  margin-top: 10px;
-  margin-bottom: 0;
-  font-size: 12px;
-  color: $gray-3;
-}
-</style>
-
 <script>
 import Data from '@/data/data.json'
 import formatConfirmedCases from '@/utils/formatConfirmedCases'
 import DataView from '@/components/DataView.vue'
 import ConfirmedCasesDetailsTable from '@/components/ConfirmedCasesDetailsTable.vue'
-
 export default {
   components: {
     DataView,
@@ -43,12 +44,10 @@ export default {
   data() {
     // 検査陽性者の状況
     const confirmedCases = formatConfirmedCases(Data.main_summary)
-
-    const data = {
+    return {
       Data,
       confirmedCases
     }
-    return data
   }
 }
 </script>

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -5,24 +5,6 @@
       :title-id="'details-of-confirmed-cases'"
       :date="Data.patients.date"
     >
-      <template v-slot:description>
-        <ul>
-          <li>
-            {{
-              $t(
-                '（注）「重症」は、集中治療室（ICU）等での管理又は人工呼吸器管理が必要な患者数'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '（注）退院者数の把握には一定の期間を要しており、確認次第数値を更新している'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
       <confirmed-cases-details-table
         :aria-label="$t('検査陽性者の状況')"
         v-bind="confirmedCases"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,7 +23,7 @@
     />
     <v-row class="DataBlock">
       <!-- 検査陽性者の状況 -->
-      <!--<confirmed-cases-details-card />-->
+      <confirmed-cases-details-card />
       <!-- 陽性患者数 -->
       <confirmed-cases-number-card />
       <!-- 検査実施件数 -->
@@ -46,7 +46,7 @@ import StaticInfo from '@/components/StaticInfo.vue'
 import Data from '@/data/data.json'
 import inspectionsData from '@/data/inspections_summary.json'
 import News from '@/data/news.json'
-// import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
+import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
@@ -58,7 +58,7 @@ export default Vue.extend({
     PageHeader,
     WhatsNew,
     StaticInfo,
-    //    ConfirmedCasesDetailsCard,
+    ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
     ConfirmedCasesAttributesCard,
     TestedNumberCard,

--- a/utils/formatConfirmedCases.ts
+++ b/utils/formatConfirmedCases.ts
@@ -11,21 +11,37 @@ type DataType = {
           value: number
           children: [
             {
+              attr: '無症状'
+              value: number
+            },
+            {
               attr: '軽症・中等症'
               value: number
             },
             {
               attr: '重症'
               value: number
+            },
+            {
+              attr: '確認中'
+              value: number
             }
           ]
         },
         {
-          attr: '退院'
+          attr: '自宅療養'
+          value: number
+        },
+        {
+          attr: '調整中'
           value: number
         },
         {
           attr: '死亡'
+          value: number
+        },
+        {
+          attr: '退院'
           value: number
         }
       ]
@@ -37,10 +53,43 @@ type ConfirmedCasesType = {
   検査実施人数: number
   陽性者数: number
   入院中: number
+  無症状: number
   軽症中等症: number
   重症: number
+  確認中: number
+  自宅療養: number
+  調整中: number
   死亡: number
   退院: number
+}
+
+interface ChildData {
+  attr: string
+  value: number
+}
+
+type ChildDataType = {
+  attr: string
+  value: number
+  children?: ChildData[]
+}
+
+function getSelectedItem(data: DataType, key: string) {
+  let result: number | undefined
+  const recursiveSearch = (data: ChildDataType) => {
+    if (result) return
+    if (data.attr === key) {
+      result = data.value
+    } else if (data.children) {
+      data.children.forEach((child: ChildDataType) => {
+        if (result) return
+        recursiveSearch(child)
+      })
+    }
+  }
+  recursiveSearch(data)
+
+  return result || 0
 }
 
 /**
@@ -49,14 +98,17 @@ type ConfirmedCasesType = {
  * @param data - Raw data
  */
 export default (data: DataType) => {
-  const formattedData: ConfirmedCasesType = {
-    検査実施人数: data.value,
-    陽性者数: data.children[0].value,
-    入院中: data.children[0].children[0].value,
-    軽症中等症: data.children[0].children[0].children[0].value,
-    重症: data.children[0].children[0].children[1].value,
-    死亡: data.children[0].children[2].value,
-    退院: data.children[0].children[1].value
-  }
-  return formattedData
+  return {
+    検査実施人数: getSelectedItem(data, '検査実施人数'),
+    陽性者数: getSelectedItem(data, '陽性患者数'),
+    入院中: getSelectedItem(data, '入院中'),
+    無症状: getSelectedItem(data, '無症状'),
+    軽症中等症: getSelectedItem(data, '軽症・中等症'),
+    重症: getSelectedItem(data, '重症'),
+    確認中: getSelectedItem(data, '確認中'),
+    自宅療養: getSelectedItem(data, '自宅療養'),
+    調整中: getSelectedItem(data, '調整中'),
+    死亡: getSelectedItem(data, '死亡'),
+    退院: getSelectedItem(data, '退院')
+  } as ConfirmedCasesType
 }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #254

## ⛏ 変更内容 / Details of Changes
- 東京形式で、状態は北九州市様のイメージに沿って追加、修正した
- data_updaterで8種類の状態のカウントデータをdata.jsonに出すようにした

## 📸 スクリーンショット / Screenshots
- (注)の一行目が折り返している部分は、短くして一行に収まるようにした
![スクリーンショット 2020-05-29 18 44 53](https://user-images.githubusercontent.com/1393632/83313205-2f210d00-a250-11ea-9224-0cf0bcddb084.png)
