### PR TITLE
年代ソートハイフン対応

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -85,10 +85,10 @@ export default {
       const unknown = '不明'.toString()
       const investigating = '調査中'.toString()
       const emptystring = ''.toString()
-      const hyphen1 = '-'.toString()
-      const hyphen2 = '‐'.toString()
+      const hyphenMinus = '-'.toString()
+      const hyphen = '‐'.toString()
       const dash = '―'.toString()
-      const longvowel = 'ー'.toString()
+      const longVowel = 'ー'.toString()
 
       items.sort((a, b) => {
         // 両者が等しい場合は 0 を返す
@@ -151,14 +151,14 @@ export default {
           comparison = a[index[0]] === investigating ? 1 : -1
         } else if (a[index[0]] === emptystring || b[index[0]] === emptystring) {
           comparison = a[index[0]] === emptystring ? 1 : -1
-        } else if (a[index[0]] === longvowel || b[index[0]] === longvowel) {
-          comparison = a[index[0]] === longvowel ? 1 : -1
+        } else if (a[index[0]] === longVowel || b[index[0]] === longVowel) {
+          comparison = a[index[0]] === longVowel ? 1 : -1
         } else if (a[index[0]] === dash || b[index[0]] === dash) {
           comparison = a[index[0]] === dash ? 1 : -1
-        } else if (a[index[0]] === hyphen2 || b[index[0]] === hyphen2) {
-          comparison = a[index[0]] === hyphen2 ? 1 : -1
-        } else if (a[index[0]] === hyphen1 || b[index[0]] === hyphen1) {
-          comparison = a[index[0]] === hyphen1 ? 1 : -1
+        } else if (a[index[0]] === hyphen || b[index[0]] === hyphen) {
+          comparison = a[index[0]] === hyphen ? 1 : -1
+        } else if (a[index[0]] === hyphenMinus || b[index[0]] === hyphenMinus) {
+          comparison = a[index[0]] === hyphenMinus ? 1 : -1
         }
 
         return isDesc[0] ? comparison * -1 : comparison

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -142,35 +142,23 @@ export default {
         // 各項目で共通する要素のソート
         // 項目別の要素より大きい値として扱う
         // '-' < '‐' < '―' < 'ー' < ''(空文字) < '調査中' < '不明' となるようにソートする
-
-        if (a[index[0]] === hyphen1 || b[index[0]] === hyphen1) {
-          comparison = a[index[0]] === hyphen1 ? 1 : -1
-        }
-        if (a[index[0]] === hyphen2 || b[index[0]] === hyphen2) {
-          comparison = a[index[0]] === hyphen2 ? 1 : -1
-        }
-        if (a[index[0]] === dash || b[index[0]] === dash) {
-          comparison = a[index[0]] === dash ? 1 : -1
-        }
-        if (a[index[0]] === longvowel || b[index[0]] === longvowel) {
-          comparison = a[index[0]] === longvowel ? 1 : -1
-        }
-        if (a[index[0]] === emptystring || b[index[0]] === emptystring) {
-          comparison = a[index[0]] === emptystring ? 1 : -1
-        }
-
-        // 「調査中」は年代に限らず、居住地にも存在するので、年代ソートの外に置いている。
-        // 内容としては、「不明」の次に高い(大きい)ものとして扱う。
-        // 日本語の場合、「調査中」は「不明」より低い(小さい)ものとして扱われるが、
-        // 他言語の場合はそうではないため、ここで統一している。
-        if (a[index[0]] === investigating || b[index[0]] === investigating) {
-          comparison = a[index[0]] === investigating ? 1 : -1
-        }
-
-        // 「不明」は年代に限らず、性別にも存在するので、年代ソートの外に置いている。
-        // 内容としては一番高い(大きい)ものとして扱う。
         if (a[index[0]] === unknown || b[index[0]] === unknown) {
           comparison = a[index[0]] === unknown ? 1 : -1
+        } else if (
+          a[index[0]] === investigating ||
+          b[index[0]] === investigating
+        ) {
+          comparison = a[index[0]] === investigating ? 1 : -1
+        } else if (a[index[0]] === emptystring || b[index[0]] === emptystring) {
+          comparison = a[index[0]] === emptystring ? 1 : -1
+        } else if (a[index[0]] === longvowel || b[index[0]] === longvowel) {
+          comparison = a[index[0]] === longvowel ? 1 : -1
+        } else if (a[index[0]] === dash || b[index[0]] === dash) {
+          comparison = a[index[0]] === dash ? 1 : -1
+        } else if (a[index[0]] === hyphen2 || b[index[0]] === hyphen2) {
+          comparison = a[index[0]] === hyphen2 ? 1 : -1
+        } else if (a[index[0]] === hyphen1 || b[index[0]] === hyphen1) {
+          comparison = a[index[0]] === hyphen1 ? 1 : -1
         }
 
         return isDesc[0] ? comparison * -1 : comparison

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -84,6 +84,12 @@ export default {
       const lt100 = '100代'.toString()
       const unknown = '不明'.toString()
       const investigating = '調査中'.toString()
+      const emptystring = ''.toString()
+      const hyphen1 = '-'.toString()
+      const hyphen2 = '‐'.toString()
+      const dash = '―'.toString()
+      const longvowel = 'ー'.toString()
+
       items.sort((a, b) => {
         // 両者が等しい場合は 0 を返す
         if (a[index[0]] === b[index[0]]) {
@@ -94,9 +100,7 @@ export default {
 
         // '10歳未満' < '10代' ... '90代' < '100歳以上' となるようにソートする
         // 「10歳未満」同士を比較する場合、と「100歳以上」同士を比較する場合、更にそうでない場合に場合分け
-        if (index[0] === '年代' && (a[index[0]] === '' || b[index[0]] === '')) {
-          comparison = a[index[0]] === '' ? -1 : 1
-        } else if (
+        if (
           index[0] === '年代' &&
           (a[index[0]] === age0 || b[index[0]] === age0)
         ) {
@@ -133,6 +137,26 @@ export default {
           } else if (aDate[0] < bDate[0]) {
             comparison = -1
           }
+        }
+
+        // 各項目で共通する要素のソート
+        // 項目別の要素より大きい値として扱う
+        // '-' < '‐' < '―' < 'ー' < ''(空文字) < '調査中' < '不明' となるようにソートする
+
+        if (a[index[0]] === hyphen1 || b[index[0]] === hyphen1) {
+          comparison = a[index[0]] === hyphen1 ? 1 : -1
+        }
+        if (a[index[0]] === hyphen2 || b[index[0]] === hyphen2) {
+          comparison = a[index[0]] === hyphen2 ? 1 : -1
+        }
+        if (a[index[0]] === dash || b[index[0]] === dash) {
+          comparison = a[index[0]] === dash ? 1 : -1
+        }
+        if (a[index[0]] === longvowel || b[index[0]] === longvowel) {
+          comparison = a[index[0]] === longvowel ? 1 : -1
+        }
+        if (a[index[0]] === emptystring || b[index[0]] === emptystring) {
+          comparison = a[index[0]] === emptystring ? 1 : -1
         }
 
         // 「調査中」は年代に限らず、居住地にも存在するので、年代ソートの外に置いている。


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1416

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 陽性患者の属性の表の年代項目ソートにハイフンを考慮
   全項目共通で行うソートの順位を以下のようにしました
   '-' < '‐' < '―' < 'ー' < ''(空文字) < '調査中' < '不明' 
- 他項目でも空文字の考慮を扱えるように変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
